### PR TITLE
Add Gist module as proposed for base CC:T

### DIFF
--- a/illuaminate.sexp
+++ b/illuaminate.sexp
@@ -28,7 +28,7 @@
 (at /src/
   (lint
     (globals
-      :max term colours keys)))
+      :max term colours keys colors http textutils fs settings read write print)))
 
 (at /spec/
   (lint

--- a/illuaminate.sexp
+++ b/illuaminate.sexp
@@ -33,4 +33,4 @@
 (at /spec/
   (lint
     (globals
-      :max describe expect it pending stub fail sleep keys)))
+      :max describe expect it pending stub fail sleep keys fs textutils)))

--- a/spec-data/gist-data.json
+++ b/spec-data/gist-data.json
@@ -1,0 +1,145 @@
+{
+    "url": "https://api.github.com/gists/aa5a315d61ae9438b18d",
+    "forks_url": "https://api.github.com/gists/aa5a315d61ae9438b18d/forks",
+    "commits_url": "https://api.github.com/gists/aa5a315d61ae9438b18d/commits",
+    "id": "aa5a315d61ae9438b18d",
+    "node_id": "MDQ6R2lzdGFhNWEzMTVkNjFhZTk0MzhiMThk",
+    "git_pull_url": "https://gist.github.com/aa5a315d61ae9438b18d.git",
+    "git_push_url": "https://gist.github.com/aa5a315d61ae9438b18d.git",
+    "html_url": "https://gist.github.com/aa5a315d61ae9438b18d",
+    "files": {
+        "init.lua": {
+            "filename": "init.lua",
+            "type": "application/x-lua",
+            "language": "Lua",
+            "raw_url": "aaaaa",
+            "size": 1,
+            "truncated": false,
+            "content": "print(\"Hello\", ...) return 7, 4"
+        },
+        "hello_world.rb": {
+            "filename": "hello_world.rb",
+            "type": "application/x-ruby",
+            "language": "Ruby",
+            "raw_url": "https://gist.githubusercontent.com/octocat/6cad326836d38bd3a7ae/raw/db9c55113504e46fa076e7df3a04ce592e2e86d8/hello_world.rb",
+            "size": 167,
+            "truncated": false,
+            "content": "class HelloWorld\n   def initialize(name)\n      @name = name.capitalize\n   end\n   def sayHi\n      puts \"Hello !\"\n   end\nend\n\nhello = HelloWorld.new(\"World\")\nhello.sayHi"
+        },
+        "hello_world.py": {
+            "filename": "hello_world.py",
+            "type": "application/x-python",
+            "language": "Python",
+            "raw_url": "https://gist.githubusercontent.com/octocat/e29f3839074953e1cc2934867fa5f2d2/raw/99c1bf3a345505c2e6195198d5f8c36267de570b/hello_world.py",
+            "size": 199,
+            "truncated": false,
+            "content": "class HelloWorld:\n\n    def __init__(self, name):\n        self.name = name.capitalize()\n       \n    def sayHi(self):\n        print \"Hello \" + self.name + \"!\"\n\nhello = HelloWorld(\"world\")\nhello.sayHi()"
+        },
+        "hello_world_ruby.txt": {
+            "filename": "hello_world_ruby.txt",
+            "type": "text/plain",
+            "language": "Text",
+            "raw_url": "https://gist.githubusercontent.com/octocat/e29f3839074953e1cc2934867fa5f2d2/raw/9e4544db60e01a261aac098592b11333704e9082/hello_world_ruby.txt",
+            "size": 46,
+            "truncated": false,
+            "content": "Run `ruby hello_world.rb` to print Hello World"
+        },
+        "hello_world_python.txt": {
+            "filename": "hello_world_python.txt",
+            "type": "text/plain",
+            "language": "Text",
+            "raw_url": "https://gist.githubusercontent.com/octocat/e29f3839074953e1cc2934867fa5f2d2/raw/076b4b78c10c9b7e1e0b73ffb99631bfc948de3b/hello_world_python.txt",
+            "size": 48,
+            "truncated": false,
+            "content": "Run `python hello_world.py` to print Hello World"
+        }
+    },
+    "public": true,
+    "created_at": "2010-04-14T02:15:15Z",
+    "updated_at": "2011-06-20T11:34:15Z",
+    "description": "Hello World Examples",
+    "comments": 0,
+    "user": null,
+    "comments_url": "https://api.github.com/gists/aa5a315d61ae9438b18d/comments/",
+    "owner": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+    },
+    "truncated": false,
+    "forks": [
+        {
+            "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "url": "https://api.github.com/gists/dee9c42e4998ce2ea439",
+            "id": "dee9c42e4998ce2ea439",
+            "created_at": "2011-04-14T16:00:49Z",
+            "updated_at": "2011-04-14T16:00:49Z"
+        }
+    ],
+    "history": [
+        {
+            "url": "https://api.github.com/gists/aa5a315d61ae9438b18d/57a7f021a713b1c5a6a199b54cc514735d2d462f",
+            "version": "57a7f021a713b1c5a6a199b54cc514735d2d462f",
+            "user": {
+                "login": "octocat",
+                "id": 1,
+                "node_id": "MDQ6VXNlcjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/octocat",
+                "html_url": "https://github.com/octocat",
+                "followers_url": "https://api.github.com/users/octocat/followers",
+                "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+                "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+                "organizations_url": "https://api.github.com/users/octocat/orgs",
+                "repos_url": "https://api.github.com/users/octocat/repos",
+                "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/octocat/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "change_status": {
+                "deletions": 0,
+                "additions": 180,
+                "total": 180
+            },
+            "committed_at": "2010-04-14T02:15:15Z"
+        }
+    ]
+}

--- a/spec/gist_spec.lua
+++ b/spec/gist_spec.lua
@@ -1,0 +1,112 @@
+describe("metis.http.gist", function()
+    local function setup_request()
+        stub(_G, "http", {
+            checkURL = function()
+                return true
+            end,
+            get = function()
+                local file = fs.open("/spec-data/gist-data.json", "r")
+                file.getResponseHeaders = function()
+                    local tHeader = {}
+                    tHeader["Content-Type"] = "application/json"
+                    return tHeader
+                end
+                file.getResponseCode = function()
+                    return 200
+                end
+                return file
+            end,
+            post = function(tab)
+                local file = fs.open("/spec-data/gist-data.json", "r")
+                if type(tab) == "table" and tab.method == "PATCH" then
+                    local oldReadAll = file.readAll
+                    file.readAll = function()
+                        return oldReadAll()
+                            :gsub('"hello_world.rb": %b{},\n', "")
+                            :gsub('"Hello World Examples"', '"Hello World Examples (Updated)"'), nil
+                    end
+                end
+                file.getResponseCode = function()
+                    if type(tab) ~= "table" then return 201
+                    elseif tab.method == "PATCH" then return 200
+                    else return 204 end
+                end
+                return file
+            end,
+        })
+        stub(_G, "settings", {
+            get = function()
+                return "0123456789abcdef"
+            end,
+        })
+    end
+
+    local gist = require("metis.http.gist")
+
+    describe("get", function()
+        it("downloads one file", function()
+            setup_request()
+            expect(gist.get("aa5a315d61ae9438b18d")):eq "print(\"Hello\", ...) return 7, 4"
+        end)
+
+        it("downloads the requested file", function()
+            setup_request()
+            expect(gist.get("aa5a315d61ae9438b18d/hello_world_ruby.txt")):eq "Run `ruby hello_world.rb` to print Hello World"
+        end)
+    end)
+
+    describe("getAll", function()
+        it("downloads all files", function()
+            setup_request()
+            expect(gist.getAll("aa5a315d61ae9438b18d")):same {
+                ["init.lua"] = "print(\"Hello\", ...) return 7, 4",
+                ["hello_world.rb"] = "class HelloWorld\n   def initialize(name)\n      @name = name.capitalize\n   end\n   def sayHi\n      puts \"Hello !\"\n   end\nend\n\nhello = HelloWorld.new(\"World\")\nhello.sayHi",
+                ["hello_world.py"] = "class HelloWorld:\n\n    def __init__(self, name):\n        self.name = name.capitalize()\n       \n    def sayHi(self):\n        print \"Hello \" + self.name + \"!\"\n\nhello = HelloWorld(\"world\")\nhello.sayHi()",
+                ["hello_world_ruby.txt"] = "Run `ruby hello_world.rb` to print Hello World",
+                ["hello_world_python.txt"] = "Run `python hello_world.py` to print Hello World",
+            }
+        end)
+    end)
+
+    describe("run", function()
+        it("runs a program from the internet", function()
+            setup_request()
+
+            expect(gist.run("aa5a315d61ae9438b18d", "a", "b", "c")):eq(7, 4)
+        end)
+    end)
+
+    describe("info", function()
+        it("gets info about a file", function()
+            setup_request()
+            expect(gist.info("aa5a315d61ae9438b18d")):same {
+                description = "Hello World Examples",
+                author = "octocat",
+                revisionCount = 1,
+                files = { "hello_world.py", "hello_world.rb", "hello_world_python.txt", "hello_world_ruby.txt", "init.lua" },
+            }
+        end)
+    end)
+
+    describe("put", function()
+        it("upload a program to Gist", function()
+            setup_request()
+
+            expect(gist.put({ ["test.txt"] = "Hello" })):eq("aa5a315d61ae9438b18d", "https://gist.github.com/aa5a315d61ae9438b18d")
+        end)
+
+        it("edit a Gist", function()
+            setup_request()
+
+            expect(gist.put({ ["hello_world.rb"] = textutils.json_null }, "Hello World Examples (Updated)", "aa5a315d61ae9438b18d")):eq("aa5a315d61ae9438b18d", "https://gist.github.com/aa5a315d61ae9438b18d")
+        end)
+    end)
+
+    describe("delete", function()
+        it("delete a Gist", function()
+            setup_request()
+
+            expect(gist.delete("aa5a315d61ae9438b18d")):eq(true)
+        end)
+    end)
+end)

--- a/src/metis/http/gist.lua
+++ b/src/metis/http/gist.lua
@@ -1,0 +1,285 @@
+--- gist.lua - Gist client for ComputerCraft
+-- Made by JackMacWindows for CraftOS-PC and CC: Tweaked
+--
+-- @module cc.http.gist
+
+local expect = require and require("cc.expect").expect or dofile("/rom/modules/main/cc/expect.lua").expect
+
+if not http then
+    if _G.config ~= nil then error("Gist requires http API\nSet http_enable to true in the CraftOS-PC configuration")
+    else error("Gist requires http API\nSet http_enable to true in ComputerCraft's configuration") end
+end
+
+local gist = {}
+
+local function emptyfn() end -- to reduce memory/speed footprint when using empty functions
+
+-- Internal functions
+
+local function getGistFile(data)
+    if not data.truncated then return data.content else
+        local handle = http.get(data.raw_url)
+        if not handle then error("Could not connect to api.github.com.") end
+        if handle.getResponseCode() ~= 200 then
+            handle.close()
+            error("Failed to download file data.")
+        end
+        local d = handle.readAll()
+        handle.close()
+        return d
+    end
+end
+
+local function setTextColor(c) if term.isColor() then term.setTextColor(c) elseif c == colors.white or c == colors.yellow then term.setTextColor(colors.white) else term.setTextColor(colors.lightGray) end end
+
+local function requestAuth(headers, interactive)
+    if settings.get("gist.id") ~= nil then
+        headers.Authorization = "token " .. settings.get("gist.id")
+        return true
+    elseif interactive then
+        setTextColor(colors.yellow)
+        write("You need to add a Personal Access Token (PAK) to upload Gists. Follow the instructions at ")
+        setTextColor(colors.blue)
+        write("https://tinyurl.com/GitHubPAK")
+        setTextColor(colors.yellow)
+        write(" to generate one. Make sure to check the '")
+        setTextColor(colors.blue)
+        write("gist")
+        setTextColor(colors.yellow)
+        print("' checkbox on step 7 (under 'Select scopes'). Once done, paste it here.")
+        setTextColor(colors.lime)
+        write("PAK: ")
+        setTextColor(colors.white)
+        local pak = read()
+        if pak == nil or pak == "" then error("Invalid PAK, please try again.") end
+        settings.set("gist.id", pak)
+        settings.save(".settings")
+        headers.Authorization = "token " .. pak
+        return true
+    end
+    return false
+end
+
+-- User API - this can be loaded with require "cc.http.gist"
+
+-- ID can be either just the gist ID or a gist ID followed by a slash and a file name
+-- * If a file name is specified, retrieves that file
+-- * Otherwise, if there's only one file, retrieves that file
+-- * Otherwise, if there's a file named 'init.lua', retrieves 'init.lua'
+-- * Otherwise, if there's more than one file but only one *.lua file, retrieves the Lua file
+-- * Otherwise, retrieves the first Lua file alphabetically (with a warning)
+-- * Otherwise, fails
+
+--- Retrieves one file from a Gist using the specified ID.
+-- @tparam string id The Gist ID to download from. See above comments for more details.
+-- @tparam[opt] function progress A function to use to report status messages.
+-- @treturn string|nil The contents of the specified Gist file, or nil on error.
+-- @treturn string|nil The name of the file that was chosen to be downloaded, or a message on error.
+function gist.get(id, progress)
+    expect(1, id, "string")
+    expect(2, progress, "function", "nil")
+    progress = progress or emptyfn
+    local file
+    if id:find("/") ~= nil then id, file = id:match("^([0-9A-Fa-f:]+)/(.+)$") end
+    if id == nil or not id:match("^[0-9A-Fa-f][0-9A-Fa-f:]+[0-9A-Fa-f]$") then error("bad argument #1 to 'get' (invalid ID)", 2) end
+    if id:find(":") ~= nil then id = id:gsub(":", "/") end
+    progress("Connecting to api.github.com... ")
+    local handle = http.get("https://api.github.com/gists/" .. id)
+    if handle == nil then
+        progress("Failed.\n")
+        return nil, "Failed to connect"
+    end
+    local meta = textutils.unserializeJSON(handle.readAll())
+    local code = handle.getResponseCode()
+    handle.close()
+    if code ~= 200 then
+        progress("Failed.\n")
+        return nil, "Invalid response code (" .. code .. ")" .. (meta and ": " .. meta.message or "")
+    end
+    if meta == nil or meta.files == nil then
+        progress("Failed.\n")
+        return nil, meta and "GitHub API error: " .. meta.message or "Error parsing JSON"
+    end
+    progress("Success.\n")
+    if file then return getGistFile(meta.files[file]), file
+    elseif next(meta.files, next(meta.files)) == nil then return getGistFile(meta.files[next(meta.files)]), next(meta.files)
+    elseif meta.files["init.lua"] ~= nil then return getGistFile(meta.files["init.lua"]), "init.lua"
+    else
+        local luaFiles = {}
+        for k in pairs(meta.files) do if k:match("%.lua$") then table.insert(luaFiles, k) end end
+        table.sort(luaFiles)
+        if #luaFiles == 0 then
+            progress("Error: Could not find any Lua files to download!\n")
+            return nil, "Could not find any Lua files to download"
+        end
+        if #luaFiles > 1 then progress("Warning: More than one Lua file detected, downloading the first one alphabetically.\n") end
+        return getGistFile(meta.files[luaFiles[1]]), luaFiles[1]
+    end
+end
+
+--- Runs a specified Gist. This is a wrapper for convenience.
+-- @tparam string id The Gist ID to download from. See above comments for more details.
+-- @tparam[opt] function progress A function to use to report status messages. If
+-- this is not a function, it will be used as an argument to the script.
+-- @tparam[opt] any ... Any arguments to pass to the script.
+-- @treturn any Any results returned from the script.
+function gist.run(id, progress, ...)
+    expect(1, id, "string")
+    local args = table.pack(...)
+    if type(progress) ~= "function" and progress ~= nil then
+        table.insert(args, 1, progress)
+        progress = nil
+    end
+    local data, name = gist.get(id, progress)
+    if data == nil then return end
+    local fn, err = load(data, name, "t", _ENV)
+    if fn == nil then error(err) end
+    local retval = table.pack(pcall(fn, table.unpack(args)))
+    if not retval[1] then error(retval[2]) end
+    return table.unpack(retval, 2)
+end
+
+--- Retrieves a table of all files from a Gist.
+-- @tparam string id The Gist ID to download.
+-- @tparam[opt] function progress A function to use to report status messages.
+-- @treturn table|nil A key-value list of all files in the Gist, or nil on error.
+-- @treturn string|nil If an error occurred, a string describing the error.
+function gist.getAll(id, progress)
+    expect(1, id, "string")
+    expect(2, progress, "function", "nil")
+    progress = progress or emptyfn
+    if id:find("/") ~= nil then id = id:match("^([0-9A-Fa-f:]+)/.*$") end
+    if id == nil or not id:match("^[0-9A-Fa-f][0-9A-Fa-f:]+[0-9A-Fa-f]$") then error("bad argument #1 to 'getAll' (invalid ID)", 2) end
+    if id:find(":") ~= nil then id = id:gsub(":", "/") end
+    progress("Connecting to api.github.com... ")
+    local handle = http.get("https://api.github.com/gists/" .. id)
+    if handle == nil then progress("Failed.\n") return nil, "Failed to connect" end
+    local meta = textutils.unserializeJSON(handle.readAll())
+    local code = handle.getResponseCode()
+    handle.close()
+    if code ~= 200 then
+        progress("Failed.\n")
+        return nil, "Invalid response code (" .. code .. ")" .. (meta and ": " .. meta.message or "")
+    end
+    if meta == nil or meta.files == nil then
+        progress("Failed.\n")
+        return nil, meta and meta.message and "GitHub API error: " .. meta.message or "Error parsing JSON"
+    end
+    progress("Success.\n")
+    local retval = {}
+    for k, v in pairs(meta.files) do retval[k] = getGistFile(v) end
+    return retval
+end
+
+--- Returns some information about a Gist.
+-- @tparam string id The Gist ID to get info about.
+-- @tparam[opt] function progress A function to use to report status messages.
+-- @treturn table|nil A table of information about the Gist. The table may
+-- contain the following entries:
+--  - description: The description for the Gist.
+--  - author: The username of the author of the Gist.
+--  - revisionCount: The number of revisions that have been made to the Gist.
+--  - files: A list of all file names in the Gist, sorted alphabetically.
+-- @treturn string|nil If an error occurred, a string describing the error.
+function gist.info(id, progress)
+    expect(1, id, "string")
+    expect(2, progress, "function", "nil")
+    progress = progress or emptyfn
+    if id:find("/") ~= nil then id = id:match("^([0-9A-Fa-f:]+)/.*$") end
+    if id == nil or not id:match("^[0-9A-Fa-f][0-9A-Fa-f:]+[0-9A-Fa-f]$") then error("bad argument #1 to 'info' (invalid ID)", 2) end
+    if id:find(":") ~= nil then id = id:gsub(":", "/") end
+    progress("Connecting to api.github.com... ")
+    local handle = http.get("https://api.github.com/gists/" .. id)
+    if handle == nil then progress("Failed.\n") return nil, "Failed to connect" end
+    local meta = textutils.unserializeJSON(handle.readAll())
+    local code = handle.getResponseCode()
+    handle.close()
+    if code ~= 200 then
+        progress("Failed.\n")
+        return nil, "Invalid response code (" .. code .. ")" .. (meta and ": " .. meta.message or "")
+    end
+    if meta == nil or meta.files == nil then
+        progress("Failed.\n")
+        return nil, meta and meta.message and "GitHub API error: " .. meta.message or "Error parsing JSON"
+    end
+    local f = {}
+    for k in pairs(meta.files) do table.insert(f, k) end
+    table.sort(f)
+    progress("Success.\n")
+    return { description = meta.description, author = meta.owner.login, revisionCount = #meta.history, files = f }
+end
+
+--- Uploads a list of files to Gist, updating a previous Gist if desired.
+-- @tparam table files The files to upload to Gist. This table should be
+-- structured with a key as file name and a string with the file contents. If
+-- updating a Gist, files can be deleted by setting the data to textutils.json_null.
+-- @tparam[opt] string description The description of the Gist. This is required
+-- when updating a Gist, but is optional when uploading a Gist for the first
+-- time. If you don't want to change the description when updating, you can get
+-- the current description with gist.info() and pass in the description field.
+-- @tparam[opt] string id The ID of the Gist to update. If nil, a new Gist will
+-- be created.
+-- @tparam[opt] boolean interactive Set this to true to allow asking for a PAK
+-- if one is not available in the settings. If this is not specified, this
+-- function will return nil if gist.id is not available in the settings.
+-- @treturn string|nil The ID of the Gist, or nil on error.
+-- @treturn string|nil The URL of the Gist, or a string on error.
+function gist.put(files, description, id, interactive)
+    expect(1, files, "table")
+    expect(3, id, "string", "nil")
+    expect(2, description, "string", id == nil and "nil" or nil)
+    expect(4, interactive, "boolean", "nil")
+    if id then
+        if id:find("/") ~= nil then id = id:match("^([0-9A-Fa-f:]+)/.*$") end
+        if id == nil or not id:match("^[0-9A-Fa-f][0-9A-Fa-f:]+[0-9A-Fa-f]$") then error("bad argument #3 to 'put' (invalid ID)", 2) end
+        if id:find(":") ~= nil then id = id:gsub(":", "/") end
+    end
+    local data = { files = {}, public = true, description = description }
+    for k, v in pairs(files) do if v == textutils.json_null then data.files[k] = v else data.files[k] = { content = v } end end
+    local headers = { ["Content-Type"] = "application/json" }
+    if not requestAuth(headers, interactive) then return nil, "Authentication required" end
+    if interactive then write("Connecting to api.github.com... ") end
+    local handle
+    if id then handle = http.post{ url = "https://api.github.com/gists/" .. id, body = textutils.serializeJSON(data):gsub("\n", "n"), headers = headers, method = "PATCH" }
+    else handle = http.post("https://api.github.com/gists", textutils.serializeJSON(data):gsub("\n", "n"), headers) end
+    if handle == nil then if interactive then print("Failed.") end return nil, "Could not connect" end
+    local resp = textutils.unserializeJSON(handle.readAll())
+    if handle.getResponseCode() ~= 201 and handle.getResponseCode() ~= 200 or resp == nil then
+        if interactive then print("Failed: " .. handle.getResponseCode() .. ": " .. (resp and resp.message or "Unknown error")) end
+        handle.close()
+        return nil, "Failed: " .. handle.getResponseCode() .. ": " .. (resp and resp.message or "Unknown error")
+    end
+    handle.close()
+    if interactive then print("Success.") end
+    return resp.id, resp.html_url
+end
+
+--- Deletes a Gist.
+-- @tparam string id The Gist ID to delete.
+-- @tparam[opt] boolean interactive Set this to true to allow asking for a PAK
+-- if one is not available in the settings. If this is not specified, this
+-- function will return false if gist.id is not available in the settings.
+-- @treturn boolean Whether the request succeeded.
+-- @treturn string|nil If an error occurred, a message describing the error.
+function gist.delete(id, interactive)
+    expect(1, id, "string")
+    expect(2, interactive, "boolean", "nil")
+    if id:find("/") ~= nil or id:find(":") ~= nil then id = id:match("^([0-9A-Fa-f]+)") end
+    if id == nil or not id:match("^[0-9A-Fa-f][0-9A-Fa-f:]+[0-9A-Fa-f]$") then error("bad argument #1 to 'delete' (invalid ID)", 2) end
+    local headers = {}
+    if not requestAuth(headers, interactive) then return false, "Authentication required" end
+    if interactive then write("Connecting to api.github.com... ") end
+    local handle = http.post{ url = "https://api.github.com/gists/" .. id, headers = headers, method = "DELETE" }
+    if handle == nil then if interactive then print("Failed.") end return false, "Could not connect" end
+    if handle.getResponseCode() ~= 204 then
+        local resp = textutils.unserializeJSON(handle.readAll())
+        if interactive then print("Failed: " .. handle.getResponseCode() .. ": " .. (resp and resp.message or "Unknown error")) end
+        handle.close()
+        return false, "Failed: " .. handle.getResponseCode() .. ": " .. (resp and resp.message or "Unknown error")
+    end
+    handle.close()
+    if interactive then print("Success.") end
+    return true
+end
+
+return gist

--- a/src/metis/http/gist.lua
+++ b/src/metis/http/gist.lua
@@ -43,13 +43,13 @@ local function requestAuth(headers, interactive)
         return true
     elseif interactive then
         pp.print(
-            pp.text("You need to add a Personal Access Token (PAK) to upload Gists. Follow the instructions at ", covertColor(colors.yellow)) ..
-            pp.text("https://tinyurl.com/GitHubPAK", covertColor(colors.blue)) ..
-            pp.text(" to generate one. Make sure to check the '", covertColor(colors.yellow)) ..
-            pp.text("gist", covertColor(colors.blue)) ..
-            pp.text("' checkbox on step 7 (under 'Select scopes'). Once done, paste it here.", covertColor(colors.yellow))
+            pp.text("You need to add a Personal Access Token (PAK) to upload Gists. Follow the instructions at ", convertColor(colors.yellow)) ..
+            pp.text("https://tinyurl.com/GitHubPAK", convertColor(colors.blue)) ..
+            pp.text(" to generate one. Make sure to check the '", convertColor(colors.yellow)) ..
+            pp.text("gist", convertColor(colors.blue)) ..
+            pp.text("' checkbox on step 7 (under 'Select scopes'). Once done, paste it here.", convertColor(colors.yellow))
         )
-        term.setTextColor(covertColor(colors.lime))
+        term.setTextColor(convertColor(colors.lime))
         write("PAK: ")
         term.setTextColor(colors.white)
         local pak = read()


### PR DESCRIPTION
This PR adds the Gist module that I proposed for CC:T in SquidDev-CC/CC-Tweaked#400. This repository would probably be more of an appropriate place to put it.

<details>
<summary>Here's the original text from the pull request.</summary>
Gist is a service provided by GitHub that allows uploading small sets of text files, similar to Pastebin.

Advantages of Gist over Pastebin:
* Hosted by GitHub, meaning more reliable service
* Multiple files can be uploaded at once
* Descriptions can tell people what your files do
* Markdown & automatic syntax hightlighting online
* Files can be edited & deleted after uploading
* Tied to your GitHub account

Disadvantages of Gist:
* Requires you to log in to upload files (users are assisted in making a token for login)
* Longer IDs mean more typing (or pasting)

Since Pastebin has been having some downtime recently, and since Gist has more features than Pastebin, it may be good to have Gist available for users alongside or instead of Pastebin. I've been distributing `gist.lua` independently for a while, but I just got around to polishing it up and adding some more features, and I think it would be a great addition to the standard CraftOS tools.

The version of `gist.lua` I have included is the same as the one I ship with my emulator, CraftOS-PC. It has a few parts that are left over, but if necessary I can strip those out here (however, that may make any possible updates slightly harder to port to CC:T). It has six commands: `put`, `edit`, `delete`, `get`, `run`, and `info`. It simulates most of the behavior of `pastebin`, but also allows downloading and uploading multiple files, as well as some other new functions that are Gist-specific.

One drawback that I have had to work around is that Gist does not allow anonymous upload, but the script points the user to an online article that shows steps on creating a personal access token. (Should the program list the steps itself?) This can then be pasted into ComputerCraft, and the token will be stored in `gist.id` in the `settings` API, allowing future uploads on the same computer without having to generate another token. (Is storing the user's personal token in plaintext too insecure?)

This commit includes the `gist` program, a help document, and a test script which has passed all tests. (I will need to add some more tests since I forgot to add a few for the new commands.) Shell autocomplete has also been added, though it is somewhat incomplete due to the complex variation of the command's syntax.

You may want to [take a look at the help document](https://github.com/MCJack123/CC-Tweaked/blob/gist/src/main/resources/assets/computercraft/lua/rom/help/gist.txt) for information about the features of `gist.lua` and how to use it.
</details>